### PR TITLE
Losing contents of settings.php when there is no settings.local.php

### DIFF
--- a/src/Composer/GoComposerCommand.php
+++ b/src/Composer/GoComposerCommand.php
@@ -922,11 +922,11 @@ class GoComposerCommand extends BaseCommand
                             $flag_local = false;
                         }
                     }
+                    file_put_contents($new_file, $modified_lines);
                 }
 
 
 
-                file_put_contents($new_file, $modified_lines);
 
 
                 include $new_file;


### PR DESCRIPTION
The rewrite should be inside the condition for settings.local.php just after the foreach filling $modified_lines. Which will be empty when there is no settings.local.php